### PR TITLE
Fix some derived rules are not highlighted as a keyword

### DIFF
--- a/frontend/mode-boxprover.js
+++ b/frontend/mode-boxprover.js
@@ -28,7 +28,7 @@ var BoxProverHighlightRules = function(textClass) {
                 regex : ";(?![a-zA-Z0-9_])"
             }, {
                 token : "support.constant",
-                regex : "(?:lem|nne|copy|top\_i|bot\_e|con\_i|con\_e1|con\_e2|dis\_i1|dis\_i2|dis\_e|imp\_i|imp\_e|neg\_e|neg\_i|all\_i|all\_e|exi\_i|exi\_e|eq\_i|eq\_e)(?!;)\\b"
+                regex : "(?:lem|mt|pbc|nne|nni|copy|top\_i|bot\_e|con\_i|con\_e1|con\_e2|dis\_i1|dis\_i2|dis\_e|imp\_i|imp\_e|neg\_e|neg\_i|all\_i|all\_e|exi\_i|exi\_e|eq\_i|eq\_e)(?!;)\\b"
             }, {
                 token : "keyword.operator",
                 regex : "\\b(?:exi|all|top|bot)\\b"


### PR DESCRIPTION
Add highlighting for proof rules  If the derived rule `lem` should be highlighted, then so should these three

- `nni`
- `mt`
- `pbc`

Especially since students otherwise will think, that they did something wrong.